### PR TITLE
centos9: Add /etc/sysconfig/kernel with correct default settings

### DIFF
--- a/kiwi-desc/centos9/root/etc/sysconfig/kernel
+++ b/kiwi-desc/centos9/root/etc/sysconfig/kernel
@@ -1,0 +1,6 @@
+# UPDATEDEFAULT specifies if kernel-install should make
+# new kernels the default
+UPDATEDEFAULT=yes
+
+# DEFAULTKERNEL specifies the default kernel package type
+DEFAULTKERNEL=kernel-core


### PR DESCRIPTION
This ensures that new kernel installs will update the bootloader configuration correctly.

Reference: https://pagure.io/centos-sig-hyperscale/kiwi-descriptions/c/ce06c086c6853e4fa78f02a4c8671ac2fe891d27